### PR TITLE
Fix default DevicePropertyMap for MT7603, MT7610

### DIFF
--- a/mtk-luci-plugin/luci-app-mtkwifi/root/usr/lib/lua/mtkwifi.lua
+++ b/mtk-luci-plugin/luci-app-mtkwifi/root/usr/lib/lua/mtkwifi.lua
@@ -251,10 +251,12 @@ local WirelessModeList = {
 
 local DevicePropertyMap = {
     -- 2.4G
+    {device="MT7603", band={"0", "1", "4", "6", "7", "9"}},
     {device="MT7620", band={"0", "1", "4", "6", "7", "9"}},
     {device="MT7622", band={"0", "1", "4", "9"}},
     {device="MT7628", band={"0", "1", "4", "6", "7", "9"}},
     -- 5G
+    {device="MT7610", band={"2", "8", "11", "14", "15"}},
     {device="MT7612", band={"2", "8", "11", "14", "15"}},
     {device="MT7662", band={"2", "8", "11", "14", "15"}},
     -- Mix


### PR DESCRIPTION
Added default DevicePropertyMap for MT7603 and MT7610.
I don't know  if this is the right DevicePropertyMap for these devices, but it fix the error in the web interface (See https://github.com/Nossiac/mtk-openwrt-feeds/issues/7#issuecomment-354219926)